### PR TITLE
List: avoid mutating non-owned nodes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,8 @@
                                      [proteus "0.1.6"]
                                      [byte-streams "0.2.2"]
                                      [eftest "0.1.4"]
-                                     [virgil "0.1.7-alpha1"]]}}
+                                     [virgil "0.1.7-alpha1"]
+                                     [org.apache.commons/commons-lang3 "3.6"]]}}
   :aliases {"partest"   ["run" "-m" "bifurcan.run-tests"]
             "benchmark" ["with-profile" "bench,dev" "run" "-m" "bifurcan.benchmark-test" "benchmark"]}
   :jvm-opts ^:replace ["-server" "-XX:+UseG1GC" "-Xmx10g" "-XX:-OmitStackTraceInFastThrow"]

--- a/src/io/lacuna/bifurcan/nodes/ListNodes.java
+++ b/src/io/lacuna/bifurcan/nodes/ListNodes.java
@@ -376,7 +376,7 @@ public class ListNodes {
       } else {
         Node rn = (Node) nodes[0];
         int prevSize = rn.size();
-        Node rnPrime = rn.popFirst();
+        Node rnPrime = rn.removeFirst(editor);
         int delta = rnPrime.size() - prevSize;
 
         nodes[0] = rnPrime;
@@ -401,7 +401,7 @@ public class ListNodes {
       } else {
         Node rn = (Node) nodes[numNodes - 1];
         int prevSize = rn.size();
-        Node rnPrime = rn.popLast();
+        Node rnPrime = rn.removeLast(editor);
 
         nodes[numNodes - 1] = rnPrime;
         offsets[numNodes - 1] += rnPrime.size() - prevSize;

--- a/test/bifurcan/collection_test.clj
+++ b/test/bifurcan/collection_test.clj
@@ -251,6 +251,43 @@
           (->> s (drop start) (take (- end start)))
           (Lists/slice (List/from s) start end))))))
 
+(defspec test-list-immutable-add-first iterations
+  (prop/for-all [n (gen/choose 1 1e4)]
+  (let [x (List/from (range n))
+        xs (u/reflect-to-str x)]
+    (.addFirst x 42)
+    (= xs (u/reflect-to-str x)))))
+
+(defspec test-list-immutable-add-last iterations
+  (prop/for-all [n (gen/choose 1 1e4)]
+    (let [x (List/from (range n))
+          xs (u/reflect-to-str x)]
+      (.addLast x 42)
+      (= xs (u/reflect-to-str x)))))
+
+(defspec test-list-immutable-set iterations
+  (prop/for-all [[n i] (gen/bind
+                         (gen/choose 1 1e4)
+                         #(gen/tuple (gen/return %) (gen/choose 1 %))) ]
+    (let [x (List/from (range n))
+          xs (u/reflect-to-str x)]
+      (.set x i 42)
+      (= xs (u/reflect-to-str x)))))
+
+(defspec test-list-immutable-remove-first iterations
+  (prop/for-all [n (gen/choose 1 1e4)]
+    (let [x (List/from (range n))
+          xs (u/reflect-to-str x)]
+      (.removeFirst x)
+      (= xs (u/reflect-to-str x)))))
+
+(defspec test-list-immutable-remove-last iterations
+  (prop/for-all [n (gen/choose 1 1e4)]
+    (let [x (List/from (range n))
+          xs (u/reflect-to-str x)]
+      (.removeLast x)
+      (= xs (u/reflect-to-str x)))))
+
 ;;; IntMap
 
 (defspec test-int-map-slice iterations

--- a/test/bifurcan/test_utils.clj
+++ b/test/bifurcan/test_utils.clj
@@ -2,7 +2,11 @@
   (:require
    [clojure.test.check.generators :as gen]
    [clojure.test.check.properties :as prop]
-   [clojure.test.check.clojure-test :as ct :refer (defspec)]))
+   [clojure.test.check.clojure-test :as ct :refer (defspec)])
+  (:import
+   [org.apache.commons.lang3.builder
+    ReflectionToStringBuilder
+    RecursiveToStringStyle]))
 
 (defn actions->generator [actions]
   (->> actions
@@ -36,3 +40,9 @@
            (if-not (do ~@predicate)
              (do #_(prn ~actions) false)
              true))))))
+
+(defn reflect-to-str
+  "Recursively reflect over the object to create a string.
+  Use to snapshot object internals to assert immutability."
+  [obj]
+  (ReflectionToStringBuilder/toString obj (RecursiveToStringStyle.)))


### PR DESCRIPTION
removeFirst and removeLast on sufficiently large Lists mutated the
source list when called.  Fixed to correctly check the current editor
and clone the node when not owned.

Added tests that use reflection to compare a deep toString of the List
before and after each of the update methods.