### PR TITLE
Avoid loop iterations in Map intersection

### DIFF
--- a/src/io/lacuna/bifurcan/nodes/MapNodes.java
+++ b/src/io/lacuna/bifurcan/nodes/MapNodes.java
@@ -981,7 +981,7 @@ public class MapNodes {
   public static <K, V> Node<K, V> intersection(int shift, Object editor, Node<K, V> a, Node<K, V> b, BiPredicate<K, K> equals) {
     Node<K, V> result = new Node<K, V>(editor);
 
-    PrimitiveIterator.OfInt masks = Util.masks(a.nodemap | a.datamap | b.nodemap | b.datamap);
+    PrimitiveIterator.OfInt masks = Util.masks((a.nodemap | a.datamap) & (b.nodemap | b.datamap));
     while (masks.hasNext()) {
       int mask = masks.nextInt();
       int state = mergeState(mask, a.nodemap, a.datamap, b.nodemap, b.datamap);
@@ -1014,12 +1014,6 @@ public class MapNodes {
           if (get(b, shift, a.hashes[idx], (K) a.content[idx << 1], equals, DEFAULT_VALUE) != DEFAULT_VALUE) {
             result = transferEntry(mask, a, result);
           }
-          break;
-        case ENTRY_NONE:
-        case NODE_NONE:
-        case NONE_ENTRY:
-        case NONE_NODE:
-        case NONE_NONE:
           break;
       }
     }


### PR DESCRIPTION
I was reading your code, because my own CHAMP set operations were a huge mess of nested conditionals. I stole your switch idea and the trick of iterating only over set bits. Thanks!

Anyway, I noticed that you could skip more bits in the intersection, instead of iterating over them and then doing nothing. I removed the redundant cases too. This might be a stylistic thing, though. Or maybe it should be `assert false;`?

A similar trick should apply for difference.
And there might be similar code in IntMaps etc., I haven't checked.

(Also, I haven't tested this. I might have misunderstood something and it's wrong, or just slower.)