### PR TITLE
A few small fixes

### DIFF
--- a/test/bifurcan/benchmark_test.clj
+++ b/test/bifurcan/benchmark_test.clj
@@ -1242,6 +1242,7 @@
                            nil))
                        descriptor)]
 
+      (io/make-parents "benchmarks/data/benchmarks.edn")
       (spit "benchmarks/data/benchmarks.edn" (pr-str descriptor))
 
       (write-out-csvs descriptor)))

--- a/test/bifurcan/collection_test.clj
+++ b/test/bifurcan/collection_test.clj
@@ -344,7 +344,7 @@
   [a (IntMap.) int-map]
   (valid-map-indices? a))
 
-(u/def-collection-check test-int-map-indices iterations float-map-actions
+(u/def-collection-check test-float-map-indices iterations float-map-actions
   [a (FloatMap.) float-map]
   (valid-map-indices? a))
 
@@ -537,7 +537,7 @@
   [l (List.) bifurcan-list]
   (= l (-> l (.split 2) into-array Lists/concat)))
 
-(u/def-collection-check test-list-split iterations list-actions
+(u/def-collection-check test-list-split2 iterations list-actions
   [l (Lists/from []) bifurcan-list]
   (= l (-> l (.split 2) into-array Lists/concat)))
 
@@ -545,7 +545,7 @@
   [s (LinearSet.) bifurcan-set]
   (= s (-> s (.split 2) (set-union (LinearSet.)))))
 
-(u/def-collection-check test-linear-set-split iterations set-actions
+(u/def-collection-check test-linear-set-split2 iterations set-actions
   [s (Set.) bifurcan-set]
   (= s (-> s (.split 2) (set-union (Set.)))))
 


### PR DESCRIPTION
Create benchmarks/data directory if one does not already exist.
Without this, the attempted writing of files in that directory will
fail if it does not already exist.

Uniquify names of tests, otherwise only one of them with the same name
will be run.