### PR TITLE
Fix iterating reverse in JavaList

### DIFF
--- a/src/io/lacuna/bifurcan/Lists.java
+++ b/src/io/lacuna/bifurcan/Lists.java
@@ -162,7 +162,7 @@ public class Lists {
 
         @Override
         public boolean hasPrevious() {
-          return idx > index;
+          return idx > 0;
         }
 
         @Override


### PR DESCRIPTION
`hasPrevious` is always `false` at the moment.