### PR TITLE
Fix forking SortedSet

### DIFF
--- a/src/io/lacuna/bifurcan/SortedSet.java
+++ b/src/io/lacuna/bifurcan/SortedSet.java
@@ -96,6 +96,11 @@ public class SortedSet<V> extends ISortedSet.Mixin<V> {
   }
 
   @Override
+  public boolean isLinear() {
+    return m.isLinear();
+  }
+
+  @Override
   public SortedSet<V> forked() {
     return isLinear() ? new SortedSet<>(m.forked()) : this;
   }


### PR DESCRIPTION
Now `SortedSet#forked` always returns `this`, even if it was linearized before. This may lead to the following behavior:

```
val set = SortedSet<Int>().add(1).linear().forked()
set.add(2)
println(set.toList())
===
[1, 2]
```