### PR TITLE
Use https repository for usethesource.io

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -54,7 +54,7 @@
                        #_"-XX:CompileCommand=dontinline,io.lacuna.bifurcan.nodes.Util::mergeState"
                        ]
 
-  :repositories {"usethesource" "http://nexus.usethesource.io/content/repositories/public/"}
+  :repositories {"usethesource" "https://nexus.usethesource.io/content/repositories/public/"}
 
   ;; deployment
   :url "https://github.com/lacuna/bifurcan"


### PR DESCRIPTION
This repository is necessary to get the io.usethesource.capsule  test dependency.

Since maven 3.8.1 HTTP repositories are blocked by default. See
https://maven.apache.org/docs/3.8.1/release-notes.html