### PR TITLE
Fix a trivial fence post error causing two test map slice failures.

### DIFF
--- a/test/bifurcan/collection_test.clj
+++ b/test/bifurcan/collection_test.clj
@@ -484,7 +484,7 @@
           end   (max start end)
           s     (range (* 2 end))]
       (map=
-        (->> s (drop start) (take (inc (- end start))) (map #(vector % %)) (into {}))
+        (->> s (drop start) (take (- end start)) (map #(vector % %)) (into {}))
         (-> (->> s (map #(vector % %)) (into {})) IntMap/from (.sliceIndices start end))))))
 
 (defspec test-int-map-floor iterations
@@ -508,7 +508,7 @@
           end   (max start end)
           s     (range (* 2 end))]
       (map=
-        (->> s (drop start) (take (inc (- end start))) (map #(vector % %)) (into {}))
+        (->> s (drop start) (take (- end start)) (map #(vector % %)) (into {}))
         (-> (->> s (map #(vector % %)) (into {})) SortedMap/from (.sliceIndices start end))))))
 
 (defspec test-sorted-map-floor iterations


### PR DESCRIPTION
The slice method end value is inclusive, but the test was looking for exclusive behavior.