### PR TITLE
Add IGraph.edge(from, to, notFound)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,7 @@
                                  (some #{:benchmark :stress}
                                    (cons (:tag %) (keys %))))
                    :benchmark :benchmark
+                   :focus     :focus
                    :stress    :stress
                    :all       (constantly true)}
   :profiles {:low-mem {:jvm-opts ^:replace ["-server" "-Xmx1g" "-XX:MaxDirectMemorySize=2g" "-XX:+UseG1GC"]}

--- a/src/io/lacuna/bifurcan/DirectedAcyclicGraph.java
+++ b/src/io/lacuna/bifurcan/DirectedAcyclicGraph.java
@@ -102,6 +102,11 @@ public class DirectedAcyclicGraph<V, E> implements IGraph<V, E> {
   }
 
   @Override
+  public E edge(V src, V dst, E notFound) {
+    return graph.edge(src, dst, notFound);
+  }
+
+  @Override
   public Set<V> in(V vertex) {
     return graph.in(vertex);
   }

--- a/src/io/lacuna/bifurcan/DirectedGraph.java
+++ b/src/io/lacuna/bifurcan/DirectedGraph.java
@@ -47,7 +47,6 @@ public class DirectedGraph<V, E> implements IGraph<V, E> {
 
   @Override
   public E edge(V from, V to) {
-
     Map m = out.get(from).orElseThrow(() -> new IllegalArgumentException("no such edge"));
     Object e = m.get(to, DEFAULT);
 
@@ -56,6 +55,15 @@ public class DirectedGraph<V, E> implements IGraph<V, E> {
     } else {
       return (E) e;
     }
+  }
+
+  @Override
+  public E edge(V from, V to, E notFound) {
+    Object m = ((Map) out).get(from, DEFAULT);
+    if (m == DEFAULT) {
+      return notFound;
+    }
+    return ((Map<V, E>) m).get(to, notFound);
   }
 
   @Override

--- a/src/io/lacuna/bifurcan/Graph.java
+++ b/src/io/lacuna/bifurcan/Graph.java
@@ -67,6 +67,12 @@ public class Graph<V, E> implements IGraph<V, E> {
   }
 
   @Override
+  public E edge (V from, V to, E notFound) {
+    Object e = ((Map) edges).get(new VertexSet<>(from, to), notFound);
+    return (E) e;
+  }
+
+  @Override
   public Set<V> in(V vertex) {
     return out(vertex);
   }

--- a/src/io/lacuna/bifurcan/IGraph.java
+++ b/src/io/lacuna/bifurcan/IGraph.java
@@ -28,6 +28,14 @@ public interface IGraph<V, E> extends ICollection<IGraph<V, E>, V> {
   E edge(V from, V to);
 
   /**
+   * 
+   * @param from A vertex
+   * @param to Another vertex
+   * @return The value of the edge from {@code from} and {@code to}, or {@code notFound} if no such edge exists.
+   */
+  E edge (V from, V to, E notFound);
+
+  /**
    * In an undirected graph, this is equivalent to {@link IGraph#out(Object)}.
    *
    * @return the set of all incoming edges to {@code vertex}

--- a/test/bifurcan/graph_test.clj
+++ b/test/bifurcan/graph_test.clj
@@ -107,6 +107,15 @@
               (recur (remove #(= seed (last %)) paths')))))))
     @acc))
 
+(deftest edge-test
+  (doseq [g [(Graph.)
+             (DirectedGraph.)
+             (DirectedAcyclicGraph.)]]
+    (let [g (.link g 1 2 :meow)]
+      (is (= :meow (.edge g 1 2)))
+      (is (= :meow (.edge g 1 2 :default)))
+      (is (= :default (.edge 2 3 :default))))))
+
 ;;;
 
 (defn gen-sized-graph [init size]

--- a/test/bifurcan/graph_test.clj
+++ b/test/bifurcan/graph_test.clj
@@ -114,7 +114,7 @@
     (let [g (.link g 1 2 :meow)]
       (is (= :meow (.edge g 1 2)))
       (is (= :meow (.edge g 1 2 :default)))
-      (is (= :default (.edge 2 3 :default))))))
+      (is (= :default (.edge g 2 3 :default))))))
 
 ;;;
 


### PR DESCRIPTION
This saves a bunch of time constructing exceptions in the notFound case.