### PR TITLE
collection_test: add tests for SortedMap.slice

### DIFF
--- a/src/io/lacuna/bifurcan/utils/Iterators.java
+++ b/src/io/lacuna/bifurcan/utils/Iterators.java
@@ -102,13 +102,18 @@ public class Iterators {
     }
   }
 
+  /* Returns true if the corresponding elements of two iterators are equal,
+   * according to some BiPredicate. False otherwise. */
   public static <V> boolean equals(Iterator<V> a, Iterator<V> b, BiPredicate<V, V> equals) {
     while (a.hasNext()) {
+      if (!b.hasNext()) {
+        return false;
+      }
       if (!equals.test(a.next(), b.next())) {
         return false;
       }
     }
-    return true;
+    return !b.hasNext();
   }
 
   public static <V> Iterator<V> from(BooleanSupplier hasNext, Supplier<V> next) {

--- a/test/bifurcan/collection_test.clj
+++ b/test/bifurcan/collection_test.clj
@@ -501,7 +501,57 @@
 
 ;;; SortedMap
 
+(deftest sorted-map-slice-test
+  (let [m (SortedMap/from {1 :a, 2 :b, 3 :c, 4 :d})]
+    (testing "slice"
+      (testing "empty"
+        ; Broken: returns entire map somehow?
+        (is (map= {} (.slice m 0 0))))
+      (testing "single"
+        ; Broken: returns empty map?
+        (is (map= {1 :a} (.slice m 1 1)))
+        (is (map= {4 :d} (.slice m 4 4))))
+      (testing "middle"
+        ; Broken: returns just 2
+        (is (map= {2 :b, 3 :c} (.slice m 2 3))))
+      (testing "over the edge"
+        ; Broken: returns just 1
+        (is (map= {1 :a, 2 :b} (.slice m 0 2)))
+        ; Broken: returns just 3
+        (is (map= {3 :c, 4 :d} (.slice m 3 8)))))
+
+    (testing "sliceIndices"
+      (testing "empty"
+        (is (map= {} (.sliceIndices m 4 4))))
+      (testing "single"
+        (is (map= {1 :a} (.sliceIndices m 0 0)))
+        (is (map= {4 :d} (.sliceIndices m 3 3))))
+      (testing "middle"
+        (is (map= {2 :b, 3 :c} (.sliceIndices m 1 2))))
+      (testing "up to the edge"
+        ; Note that sliceIndices throws when given an bounds beyond the min/max
+        (is (map= {1 :a, 2 :b} (.sliceIndices m 0 1)))
+        (is (map= {3 :c, 4 :d} (.sliceIndices m 2 4)))))))
+
 (defspec test-sorted-map-slice iterations
+  (prop/for-all [start (gen/choose 1 1e4)
+                 end   (gen/choose 1 1e4)]
+    (let [start (min start end)
+          end   (max start end)
+          s     (range (* 2 end))]
+      (map=
+        (->> s
+             (drop start)
+             ; Bounds for slice are documented to be inclusive, inclusive. This
+             ; is weird because the List slice bounds are inclusive, exclusive?
+             (take (inc (- end start)))
+             (map #(vector % %))
+             (into {}))
+        (-> (->> s (map #(vector % %)) (into {}))
+            SortedMap/from
+            (.slice start end))))))
+
+(defspec test-sorted-map-slice-indices iterations
   (prop/for-all [start (gen/choose 1 1e4)
                  end (gen/choose 1 1e4)]
     (let [start (min start end)

--- a/test/bifurcan/utils_test.clj
+++ b/test/bifurcan/utils_test.clj
@@ -1,0 +1,26 @@
+(ns bifurcan.utils-test
+  (:require
+   [clojure.test :refer :all]
+   [clojure.test.check.generators :as gen]
+   [bifurcan.test-utils :as u])
+  (:import
+   [java.util
+    ArrayList]
+   [io.lacuna.bifurcan.utils
+    Iterators]))
+
+(deftest iterators-equals-test
+  (are [a b]
+       (Iterators/equals (.iterator a) (.iterator b) (u/->bi-predicate =))
+       [] []
+       [1] [1]
+       [2 2] [2 2]
+       [1 3 2] [1 3 2]
+       [nil 2] [nil 2])
+  (are [a b]
+       (not (Iterators/equals (.iterator a) (.iterator b) (u/->bi-predicate =)))
+       [1 3 2] [1 2 3]
+       [1 2] []
+       [] [3]
+       [nil] [4]
+       [4] [nil]))


### PR DESCRIPTION
I'm seeing weird behavior from SortedMap.slice and .sliceIndices. I think the docs, tests, and/or code is wrong.

For lists, .slice is documented to take [lower, upper) bounds. But for sorted maps, .slice apparently takes [lower, upper]: both inclusive. That's kind of weird in itself--possibly it's shaped this way because it's not always clear how to construct a successor to the max element. The code certainly looks like it's intended to be both inclusive. Except it doesn't actually *do* that. Slicing to 0, 0 returns the *entire* map somehow. Slicing to 1, 1 yields the empty map. Slicing to 3, 8 yields just 3, and skips 4.

There were no tests for .slice--only .sliceIndices, so I added some. Commit 65e43ad889c3f5a5b3597194ee4abc6c41558923 says that it fixed the tests for sliceIndices to reflect their inclusive, inclusive behavior. but the commit actually does the opposite: it makes the test for inclusive, exclusive.

We should align the tests and code to whatever the behavior is supposed to be. We should also document the inclusive/exclusive behavior for sliceIndices etc. It's not actually written down, and that's terribly confusing.