### PR TITLE
Fix Rope CharSequence `.toString`.

### DIFF
--- a/src/io/lacuna/bifurcan/Rope.java
+++ b/src/io/lacuna/bifurcan/Rope.java
@@ -292,6 +292,18 @@ public class Rope implements Comparable<Rope> {
       public IntStream codePoints() {
         return IntIterators.toStream(Rope.this.codePoints(), root.numCodePoints());
       }
+
+      @Override
+      public String toString() {
+	  char[] cs = new char[root.numCodeUnits()];
+	  Iterator<byte[]> it = chunks();
+	  int offset = 0;
+	  while (it.hasNext()) {
+	      offset += UnicodeChunk.writeCodeUnits(cs, offset, it.next());
+	  }
+
+	  return new String(cs);
+      }
     };
   }
 


### PR DESCRIPTION
The CharSequence returned by Rope's `.toCharSequence` doesn't override `.toString` and gives the wrong result.

```clojure
> (-> (Rope/from "hello")
      .toCharSequence
      .toString)
"io.lacuna.bifurcan.Rope$1@69be5e43"
```

This pull request uses the same implementation that Rope's `.toString` implementation uses.